### PR TITLE
PHP 8: address curl_init() no longer returning resource

### DIFF
--- a/Guzzle/Http/Curl/CurlHandle.php
+++ b/Guzzle/Http/Curl/CurlHandle.php
@@ -220,7 +220,7 @@ class CurlHandle
      */
     public function __construct($handle, $options)
     {
-        if (!is_resource($handle)) {
+        if (!is_resource($handle) && !($handle instanceof \CurlHandle)) {
             throw new InvalidArgumentException('Invalid handle provided');
         }
         if (is_array($options)) {
@@ -246,7 +246,7 @@ class CurlHandle
      */
     public function close()
     {
-        if (is_resource($this->handle)) {
+        if (is_resource($this->handle) || $this->handle instanceof \CurlHandle) {
             curl_close($this->handle);
         }
         $this->handle = null;
@@ -259,7 +259,7 @@ class CurlHandle
      */
     public function isAvailable()
     {
-        return is_resource($this->handle);
+        return is_resource($this->handle) || $this->handle instanceof \CurlHandle;
     }
 
     /**
@@ -309,7 +309,7 @@ class CurlHandle
      */
     public function getInfo($option = null)
     {
-        if (!is_resource($this->handle)) {
+        if (!is_resource($this->handle) && !($this->handle instanceof \CurlHandle)) {
             return null;
         }
 

--- a/Guzzle/Http/Curl/CurlMulti.php
+++ b/Guzzle/Http/Curl/CurlMulti.php
@@ -52,7 +52,7 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
 
     public function __destruct()
     {
-        if (is_resource($this->multiHandle)) {
+        if (is_resource($this->multiHandle) || $this->multiHandle instanceof \CurlMultiHandle) {
             curl_multi_close($this->multiHandle);
         }
     }


### PR DESCRIPTION
See: https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.resource2object

This now works on PHP 7 and PHP 8.

qa_req 0

I tested this by checking it out and running CloudSearch tests in our
app on both PHP 7 and PHP 8. CloudSearch is the only thing we use this
old SDK for.